### PR TITLE
Remove extern statements and improve path names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,12 +220,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "c_linked_list"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4964518bd3b4a8190e832886cdc0da9794f12e8e6c1613a9e90ff331c4c8724b"
-
-[[package]]
 name = "cc"
 version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -555,40 +549,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "gcc"
-version = "0.3.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
-
-[[package]]
 name = "generic-array"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
 dependencies = [
  "typenum",
-]
-
-[[package]]
-name = "get_if_addrs"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abddb55a898d32925f3148bd281174a68eeb68bbfd9a5938a57b18f506ee4ef7"
-dependencies = [
- "c_linked_list",
- "get_if_addrs-sys",
- "libc",
- "winapi 0.2.8",
-]
-
-[[package]]
-name = "get_if_addrs-sys"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d04f9fb746cf36b191c00f3ede8bde9c8e64f9f4b05ae2694a9ccf5e3f5ab48"
-dependencies = [
- "gcc",
- "libc",
 ]
 
 [[package]]
@@ -1280,10 +1246,9 @@ dependencies = [
 
 [[package]]
 name = "peach-web"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "env_logger",
- "get_if_addrs",
  "jsonrpc-client-core",
  "jsonrpc-client-http",
  "log 0.4.11",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,9 +227,9 @@ checksum = "4964518bd3b4a8190e832886cdc0da9794f12e8e6c1613a9e90ff331c4c8724b"
 
 [[package]]
 name = "cc"
-version = "1.0.65"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95752358c8f7552394baf48cd82695b345628ad3f170d607de3ca03b8dacca15"
+checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
 
 [[package]]
 name = "cfg-if"
@@ -644,9 +644,9 @@ dependencies = [
 
 [[package]]
 name = "globwalk"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "178270263374052c40502e9f607134947de75302c1348d1a0e31db67c1691446"
+checksum = "93e3af942408868f6934a7b85134a3230832b9977cf66125df2f9edcfce4ddcc"
 dependencies = [
  "bitflags",
  "ignore",
@@ -836,7 +836,7 @@ dependencies = [
  "futures",
  "jsonrpc-core",
  "log 0.4.11",
- "serde 1.0.117",
+ "serde 1.0.118",
  "serde_json",
 ]
 
@@ -862,7 +862,7 @@ checksum = "ddf83704f4e79979a424d1082dd2c1e52683058056c9280efa19ac5f6bc9033c"
 dependencies = [
  "futures",
  "log 0.3.9",
- "serde 1.0.117",
+ "serde 1.0.118",
  "serde_derive",
  "serde_json",
 ]
@@ -897,9 +897,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
+checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
 
 [[package]]
 name = "linked-hash-map"
@@ -1101,9 +1101,9 @@ dependencies = [
 
 [[package]]
 name = "net2"
-version = "0.2.36"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7cf75f38f16cb05ea017784dc6dbfd354f76c223dba37701734c4f5a9337d02"
+checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
@@ -1199,12 +1199,12 @@ checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
 name = "openssl"
-version = "0.10.30"
+version = "0.10.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d575eff3665419f9b83678ff2815858ad9d11567e082f5ac1814baba4e2bcb4"
+checksum = "8d008f51b1acffa0d3450a68606e6a51c123012edaacb0f4e1426bd978869187"
 dependencies = [
  "bitflags",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "foreign-types",
  "lazy_static",
  "libc",
@@ -1219,9 +1219,9 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.58"
+version = "0.9.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a842db4709b604f0fe5d1170ae3565899be2ad3d9cbc72dedc789ac0511f78de"
+checksum = "de52d8eabd217311538a39bba130d7dea1f1e118010fee7a033d966845e7d5fe"
 dependencies = [
  "autocfg 1.0.1",
  "cc",
@@ -1267,20 +1267,20 @@ dependencies = [
 
 [[package]]
 name = "peach-lib"
-version = "1.0.1"
-source = "git+https://github.com/peachcloud/peach-lib?branch=main#8103cb63812d6df3ecedcb02f0239a759f5a12d0"
+version = "1.1.1"
+source = "git+https://github.com/peachcloud/peach-lib?branch=main#9ef43e1195a1ea1541403ef1aab3ff2a4f07dbaf"
 dependencies = [
  "jsonrpc-client-core",
  "jsonrpc-client-http",
  "log 0.4.11",
- "serde 1.0.117",
+ "serde 1.0.118",
  "serde_derive",
  "serde_json",
 ]
 
 [[package]]
 name = "peach-web"
-version = "0.3.1"
+version = "0.3.3"
 dependencies = [
  "env_logger",
  "get_if_addrs",
@@ -1292,10 +1292,9 @@ dependencies = [
  "percent-encoding 2.1.0",
  "rocket",
  "rocket_contrib",
- "serde 1.0.117",
- "serde_derive",
+ "serde 1.0.118",
  "serde_json",
- "snafu 0.6.9",
+ "snafu 0.6.10",
  "tera 1.5.0",
  "websocket",
  "xdg",
@@ -1364,7 +1363,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.53",
+ "syn 1.0.54",
 ]
 
 [[package]]
@@ -1703,7 +1702,7 @@ dependencies = [
  "log 0.4.11",
  "notify",
  "rocket",
- "serde 1.0.117",
+ "serde 1.0.118",
  "serde_json",
  "tera 0.11.20",
 ]
@@ -1719,7 +1718,7 @@ dependencies = [
  "indexmap",
  "pear",
  "percent-encoding 1.0.1",
- "smallvec 1.5.0",
+ "smallvec 1.5.1",
  "state",
  "time",
  "unicode-xid 0.1.0",
@@ -1829,9 +1828,12 @@ checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
 
 [[package]]
 name = "serde"
-version = "1.0.117"
+version = "1.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b88fa983de7720629c9387e9f517353ed404164b1e482c970a90c1a4aaf7dc1a"
+checksum = "06c64263859d87aa2eb554587e2d23183398d617427327cf2b3d0ed8c69e4800"
+dependencies = [
+ "serde_derive",
+]
 
 [[package]]
 name = "serde-hjson"
@@ -1848,25 +1850,25 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.117"
+version = "1.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbd1ae72adb44aab48f325a02444a5fc079349a8d804c1fc922aed3f7454c74e"
+checksum = "c84d3526699cd55261af4b941e4e725444df67aa4f9e6a3564f18030d12672df"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.53",
+ "syn 1.0.54",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.59"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcac07dbffa1c65e7f816ab9eba78eb142c6d44410f4eeba1e26e4f5dfa56b95"
+checksum = "1500e84d27fe482ed1dc791a56eddc2f230046a040fa908c08bda1d9fb615779"
 dependencies = [
  "indexmap",
  "itoa",
  "ryu",
- "serde 1.0.117",
+ "serde 1.0.118",
 ]
 
 [[package]]
@@ -1886,7 +1888,7 @@ checksum = "f7baae0a99f1a324984bcdc5f0718384c1f69775f1c7eec8b859b71b443e3fd7"
 dependencies = [
  "dtoa",
  "linked-hash-map 0.5.3",
- "serde 1.0.117",
+ "serde 1.0.118",
  "yaml-rust",
 ]
 
@@ -1952,9 +1954,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acad6f34eb9e8a259d3283d1e8c1d34d7415943d4895f65cc73813c7396fc85"
+checksum = "ae524f056d7d770e174287294f562e95044c68e88dec909a00d2094805db9d75"
 
 [[package]]
 name = "snafu"
@@ -1968,12 +1970,12 @@ dependencies = [
 
 [[package]]
 name = "snafu"
-version = "0.6.9"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c4e6046e4691afe918fd1b603fd6e515bcda5388a1092a9edbada307d159f09"
+checksum = "eab12d3c261b2308b0d80c26fffb58d17eba81a4be97890101f416b478c79ca7"
 dependencies = [
  "doc-comment",
- "snafu-derive 0.6.9",
+ "snafu-derive 0.6.10",
 ]
 
 [[package]]
@@ -1989,13 +1991,13 @@ dependencies = [
 
 [[package]]
 name = "snafu-derive"
-version = "0.6.9"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7073448732a89f2f3e6581989106067f403d378faeafb4a50812eb814170d3e5"
+checksum = "1508efa03c362e23817f96cde18abed596a25219a8b2c66e8db33c03543d315b"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.53",
+ "syn 1.0.54",
 ]
 
 [[package]]
@@ -2029,9 +2031,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.53"
+version = "1.0.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8833e20724c24de12bbaba5ad230ea61c3eafb05b881c7c9d3cfe8638b187e68"
+checksum = "9a2af957a63d6bd42255c359c93d9bfdb97076bd3b820897ce55ffbfbf107f44"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -2082,7 +2084,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "regex",
- "serde 1.0.117",
+ "serde 1.0.118",
  "serde_json",
  "slug",
  "unic-segment 0.7.0",
@@ -2105,7 +2107,7 @@ dependencies = [
  "pest_derive",
  "rand 0.7.3",
  "regex",
- "serde 1.0.117",
+ "serde 1.0.118",
  "serde_json",
  "slug",
  "unic-segment 0.9.0",
@@ -2192,9 +2194,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-core"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeeffbbb94209023feaef3c196a41cbcdafa06b4a6f893f68779bb5e53796f71"
+checksum = "87b1395334443abca552f63d4f61d0486f12377c2ba8b368e523f89e828cffd4"
 dependencies = [
  "bytes",
  "futures",
@@ -2400,7 +2402,7 @@ version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
 dependencies = [
- "serde 1.0.117",
+ "serde 1.0.118",
 ]
 
 [[package]]
@@ -2410,7 +2412,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75cf45bb0bef80604d001caaec0d09da99611b3c0fd39d3080468875cdb65645"
 dependencies = [
  "indexmap",
- "serde 1.0.117",
+ "serde 1.0.118",
 ]
 
 [[package]]
@@ -2787,6 +2789,6 @@ checksum = "9fc79f4a1e39857fc00c3f662cbf2651c771f00e9c15fe2abc341806bd46bd71"
 
 [[package]]
 name = "zeroize"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f33972566adbd2d3588b0491eb94b98b43695c4ef897903470ede4f3f5a28a"
+checksum = "81a974bcdd357f0dca4d41677db03436324d45a4c9ed2d0b873a5a360ce41c36"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2581,9 +2581,9 @@ dependencies = [
 
 [[package]]
 name = "vcpkg"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c"
+checksum = "b00bca6106a5e23f3eee943593759b7fcddb00554332e856d990c893966879fb"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,9 +44,8 @@ nest = "1.0.0"
 peach-lib = { git = "https://github.com/peachcloud/peach-lib", branch = "main" }
 percent-encoding = "2.1.0"
 rocket = "0.4.6"
-serde = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_derive = "1.0"
 snafu = "0.6"
 tera = "1.5"
 websocket = "0.26"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "peach-web"
-version = "0.3.3"
+version = "0.4.0"
 authors = ["Andrew Reid <gnomad@cryptolab.net>"]
 edition = "2018"
 description = "peach-web is a web application which provides a web interface for monitoring and interacting with the PeachCloud device. This allows administration of the single-board computer (ie. Raspberry Pi) running PeachCloud, as well as the ssb-server and related plugins."
@@ -36,7 +36,6 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 env_logger = "0.8"
-get_if_addrs = "0.5"
 jsonrpc-client-core = "0.5"
 jsonrpc-client-http = "0.5"
 log = "0.4"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # peach-web
 
-[![Build Status](https://travis-ci.com/peachcloud/peach-web.svg?branch=master)](https://travis-ci.com/peachcloud/peach-web) ![Generic badge](https://img.shields.io/badge/version-0.3.3-<COLOR>.svg)
+[![Build Status](https://travis-ci.com/peachcloud/peach-web.svg?branch=master)](https://travis-ci.com/peachcloud/peach-web) ![Generic badge](https://img.shields.io/badge/version-0.4.0-<COLOR>.svg)
 
 ## Web Interface for PeachCloud
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -6,13 +6,17 @@
 
 use std::collections::HashMap;
 
-use crate::monitor::*;
-use crate::network::*;
+use serde::Serialize;
 
 use peach_lib::network_client;
 use peach_lib::oled_client;
 use peach_lib::stats_client;
 use peach_lib::stats_client::{CpuStatPercentages, DiskUsage, LoadAverage, MemStat, Traffic};
+
+use crate::monitor;
+use crate::monitor::{Alert, Data, Threshold};
+use crate::network;
+use crate::network::{AccessPoint, Networks, Scan};
 
 #[derive(Debug, Serialize)]
 pub struct ErrorContext {
@@ -160,10 +164,10 @@ pub struct NetworkAlertContext {
 
 impl NetworkAlertContext {
     pub fn build() -> NetworkAlertContext {
-        let alert = get_alerts().unwrap();
+        let alert = monitor::get_alerts().unwrap();
         // stored wifi data values as bytes
-        let stored_traffic = get_data().unwrap();
-        let threshold = get_thresholds().unwrap();
+        let stored_traffic = monitor::get_data().unwrap();
+        let threshold = monitor::get_thresholds().unwrap();
         // current wifi traffic values as bytes
         let traffic = match network_client::traffic("wlan0") {
             Ok(t) => t,
@@ -610,7 +614,7 @@ pub struct NetworkListContext {
 
 impl NetworkListContext {
     pub fn build() -> NetworkListContext {
-        network_list_context("wlan0").unwrap()
+        network::network_list_context("wlan0").unwrap()
     }
 }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -614,7 +614,7 @@ pub struct NetworkListContext {
 
 impl NetworkListContext {
     pub fn build() -> NetworkListContext {
-        network::network_list_context("wlan0").unwrap()
+        network::list_context("wlan0").unwrap()
     }
 }
 

--- a/src/device.rs
+++ b/src/device.rs
@@ -6,7 +6,7 @@ use std::process::{Command, Output};
 use log::info;
 
 /// Executes a system command to reboot the device immediately.
-pub fn device_reboot() -> io::Result<Output> {
+pub fn reboot() -> io::Result<Output> {
     info!("Rebooting the device");
     // ideally, we'd like to reboot after 5 seconds to allow time for JSON
     // response but this is not possible with the `shutdown` command alone.
@@ -19,7 +19,7 @@ pub fn device_reboot() -> io::Result<Output> {
 }
 
 /// Executes a system command to shutdown the device immediately.
-pub fn device_shutdown() -> io::Result<Output> {
+pub fn shutdown() -> io::Result<Output> {
     info!("Shutting down the device");
     // ideally, we'd like to reboot after 5 seconds to allow time for JSON
     // response but this is not possible with the `shutdown` command alone.

--- a/src/device.rs
+++ b/src/device.rs
@@ -3,6 +3,8 @@
 use std::io;
 use std::process::{Command, Output};
 
+use log::info;
+
 /// Executes a system command to reboot the device immediately.
 pub fn device_reboot() -> io::Result<Output> {
     info!("Rebooting the device");

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,5 @@
 //! Basic error handling for the network, OLED and stats JSON-RPC clients.
 
-extern crate jsonrpc_client_core;
-extern crate jsonrpc_client_http;
-
 use std::error;
 
 pub type BoxError = Box<dyn error::Error>;

--- a/src/json_api.rs
+++ b/src/json_api.rs
@@ -58,7 +58,7 @@ pub struct JsonResponse {
 // reboot the device
 #[post("/api/v1/device/reboot")]
 pub fn reboot_device() -> Json<JsonResponse> {
-    match device::device_reboot() {
+    match device::reboot() {
         Ok(_) => {
             debug!("Going down for reboot...");
             let status = "success".to_string();
@@ -77,7 +77,7 @@ pub fn reboot_device() -> Json<JsonResponse> {
 // shutdown the device
 #[post("/api/v1/device/shutdown")]
 pub fn shutdown_device() -> Json<JsonResponse> {
-    match device::device_shutdown() {
+    match device::shutdown() {
         Ok(_) => {
             debug!("Going down for shutdown...");
             let status = "success".to_string();
@@ -289,7 +289,7 @@ pub fn connect_ap(ssid: Json<Ssid>) -> Json<JsonResponse> {
 #[post("/api/v1/network/wifi/disconnect", data = "<ssid>")]
 pub fn disconnect_ap(ssid: Json<Ssid>) -> Json<JsonResponse> {
     // attempt to disable the current network for wlan0 interface
-    match network::network_disable("wlan0", &ssid.ssid) {
+    match network::disable("wlan0", &ssid.ssid) {
         Ok(_) => {
             let status = "success".to_string();
             let msg = "Disconnected from WiFi network.".to_string();
@@ -306,7 +306,7 @@ pub fn disconnect_ap(ssid: Json<Ssid>) -> Json<JsonResponse> {
 #[post("/api/v1/network/wifi/forget", data = "<network>")]
 pub fn forget_ap(network: Json<Ssid>) -> Json<JsonResponse> {
     let ssid = &network.ssid;
-    match network::forget_network("wlan0", &ssid) {
+    match network::forget("wlan0", &ssid) {
         Ok(_) => {
             debug!("Removed WiFi credentials for chosen network.");
             let status = "success".to_string();

--- a/src/json_api.rs
+++ b/src/json_api.rs
@@ -29,19 +29,22 @@
 //! | GET    | /api/v1/ping/oled                | Ping `peach-oled`             |
 //! | GET    | /api/v1/ping/stats               | Ping `peach-stats`            |
 
-extern crate jsonrpc_client_http;
-extern crate serde_derive;
-
-use crate::device::*;
-use crate::monitor::*;
-use crate::network::*;
+use log::{debug, warn};
+use rocket::{get, post};
+use rocket_contrib::json;
+use rocket_contrib::json::{Json, JsonValue};
+use serde::Serialize;
 
 use peach_lib::network_client;
 use peach_lib::oled_client;
 use peach_lib::stats_client;
 use peach_lib::stats_client::Traffic;
 
-use rocket_contrib::json::{Json, JsonValue};
+use crate::device;
+use crate::monitor;
+use crate::monitor::Threshold;
+use crate::network;
+use crate::network::{Ssid, WiFi};
 
 #[derive(Serialize)]
 pub struct JsonResponse {
@@ -55,7 +58,7 @@ pub struct JsonResponse {
 // reboot the device
 #[post("/api/v1/device/reboot")]
 pub fn reboot_device() -> Json<JsonResponse> {
-    match device_reboot() {
+    match device::device_reboot() {
         Ok(_) => {
             debug!("Going down for reboot...");
             let status = "success".to_string();
@@ -74,7 +77,7 @@ pub fn reboot_device() -> Json<JsonResponse> {
 // shutdown the device
 #[post("/api/v1/device/shutdown")]
 pub fn shutdown_device() -> Json<JsonResponse> {
-    match device_shutdown() {
+    match device::device_shutdown() {
         Ok(_) => {
             debug!("Going down for shutdown...");
             let status = "success".to_string();
@@ -286,7 +289,7 @@ pub fn connect_ap(ssid: Json<Ssid>) -> Json<JsonResponse> {
 #[post("/api/v1/network/wifi/disconnect", data = "<ssid>")]
 pub fn disconnect_ap(ssid: Json<Ssid>) -> Json<JsonResponse> {
     // attempt to disable the current network for wlan0 interface
-    match network_disable("wlan0", &ssid.ssid) {
+    match network::network_disable("wlan0", &ssid.ssid) {
         Ok(_) => {
             let status = "success".to_string();
             let msg = "Disconnected from WiFi network.".to_string();
@@ -303,7 +306,7 @@ pub fn disconnect_ap(ssid: Json<Ssid>) -> Json<JsonResponse> {
 #[post("/api/v1/network/wifi/forget", data = "<network>")]
 pub fn forget_ap(network: Json<Ssid>) -> Json<JsonResponse> {
     let ssid = &network.ssid;
-    match forget_network("wlan0", &ssid) {
+    match network::forget_network("wlan0", &ssid) {
         Ok(_) => {
             debug!("Removed WiFi credentials for chosen network.");
             let status = "success".to_string();
@@ -326,7 +329,7 @@ pub fn modify_password(wifi: Json<WiFi>) -> Json<JsonResponse> {
     // we are using a helper function (`update_password`) to delete the old
     // credentials and add the new ones. this is because the wpa_cli method
     // for updating the password does not work.
-    match update_password("wlan0", ssid, pass) {
+    match network::update_password("wlan0", ssid, pass) {
         Ok(_) => {
             debug!("WiFi password updated for chosen network.");
             let status = "success".to_string();
@@ -344,7 +347,7 @@ pub fn modify_password(wifi: Json<WiFi>) -> Json<JsonResponse> {
 
 #[post("/api/v1/network/wifi/usage", data = "<thresholds>")]
 pub fn update_wifi_alerts(thresholds: Json<Threshold>) -> Json<JsonResponse> {
-    match update_store(thresholds.into_inner()) {
+    match monitor::update_store(thresholds.into_inner()) {
         Ok(_) => {
             debug!("WiFi data usage thresholds updated.");
             let status = "success".to_string();
@@ -362,7 +365,7 @@ pub fn update_wifi_alerts(thresholds: Json<Threshold>) -> Json<JsonResponse> {
 
 #[post("/api/v1/network/wifi/usage/reset")]
 pub fn reset_data_total() -> Json<JsonResponse> {
-    match reset_data() {
+    match monitor::reset_data() {
         Ok(_) => {
             debug!("Reset network data usage total.");
             let traffic = match network_client::traffic("wlan0") {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ fn rocket() -> rocket::Rocket {
                 login,              // WEB ROUTE
                 logout,             // WEB ROUTE
                 messages,           // WEB ROUTE
-                network,            // WEB ROUTE
+                network_home,       // WEB ROUTE
                 network_add_ssid,   // WEB ROUTE
                 network_add_wifi,   // WEB ROUTE
                 network_detail,     // WEB ROUTE

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,20 +25,6 @@
 
 #![feature(proc_macro_hygiene, decl_macro)]
 
-extern crate get_if_addrs;
-extern crate jsonrpc_client_core;
-extern crate jsonrpc_client_http;
-#[macro_use]
-extern crate log;
-#[macro_use]
-extern crate rocket;
-#[macro_use]
-extern crate rocket_contrib;
-#[macro_use]
-extern crate serde_derive;
-extern crate tera;
-extern crate websocket;
-
 pub mod context;
 pub mod device;
 pub mod error;
@@ -52,12 +38,15 @@ mod ws;
 
 use std::{env, thread};
 
+use log::{debug, error, info};
+
+use rocket::{catchers, routes};
+use rocket_contrib::templates::Template;
+
 use crate::error::BoxError;
 use crate::json_api::*;
 use crate::routes::*;
 use crate::ws::*;
-
-use rocket_contrib::templates::Template;
 
 // create rocket instance & mount web & json routes (makes testing easier)
 fn rocket() -> rocket::Rocket {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,8 @@
 //! Initialize the logger and run the application, catching any errors.
 
-extern crate peach_web;
-#[macro_use]
-extern crate log;
-extern crate env_logger;
-
 use std::process;
+
+use log::error;
 
 fn main() {
     // initialize the logger

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -3,6 +3,8 @@
 use std::convert::TryInto;
 
 use nest::{Error, Store, Value};
+use rocket::request::FromForm;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 /// Network traffic data total

--- a/src/network.rs
+++ b/src/network.rs
@@ -1,12 +1,14 @@
 //! Provides network-related methods, data structures and helper functions which
 //! utilise the JSON-RPC `peach-network` microservice.
 
-extern crate jsonrpc_client_http;
-
 use std::collections::HashMap;
 use std::env;
 
 use jsonrpc_client_http::HttpTransport;
+use log::{debug, info};
+use rocket::request::FromForm;
+use rocket::UriDisplayQuery;
+use serde::{Deserialize, Serialize};
 
 use peach_lib::network_client;
 

--- a/src/network.rs
+++ b/src/network.rs
@@ -86,7 +86,7 @@ pub fn check_saved_aps(ssid: &str) -> std::result::Result<bool, NetworkError> {
 ///
 /// * `iface` - A string slice containing the network interface identifier.
 /// * `ssid` - A string slice containing the SSID of a network.
-pub fn network_disable(iface: &str, ssid: &str) -> std::result::Result<String, NetworkError> {
+pub fn disable(iface: &str, ssid: &str) -> std::result::Result<String, NetworkError> {
     debug!("Creating HTTP transport for network client.");
     let transport = HttpTransport::new().standalone()?;
     let http_addr =
@@ -116,7 +116,7 @@ pub fn network_disable(iface: &str, ssid: &str) -> std::result::Result<String, N
 ///
 /// * `iface` - A string slice containing the network interface identifier.
 /// * `ssid` - A string slice containing the SSID of a network.
-pub fn forget_network(iface: &str, ssid: &str) -> std::result::Result<String, NetworkError> {
+pub fn forget(iface: &str, ssid: &str) -> std::result::Result<String, NetworkError> {
     debug!("Creating HTTP transport for network client.");
     let transport = HttpTransport::new().standalone()?;
     let http_addr =
@@ -196,7 +196,7 @@ pub fn update_password(
 /// # Arguments
 ///
 /// * `iface` - A string slice containing the network interface identifier.
-pub fn network_list_context(iface: &str) -> std::result::Result<NetworkListContext, NetworkError> {
+pub fn list_context(iface: &str) -> std::result::Result<NetworkListContext, NetworkError> {
     debug!("Creating HTTP transport for network client.");
     let transport = HttpTransport::new().standalone()?;
     let http_addr =

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -38,20 +38,20 @@
 
 use std::path::{Path, PathBuf};
 
+use log::{debug, warn};
+use percent_encoding::percent_decode;
+use rocket::http::RawStr;
+use rocket::request::{FlashMessage, Form};
+use rocket::response::{Flash, NamedFile, Redirect};
+use rocket::{catch, get, post, uri};
+use rocket_contrib::templates::Template;
+
+use peach_lib::network_client;
+
 use crate::context::*;
 use crate::device::*;
 use crate::monitor::*;
 use crate::network::*;
-
-use peach_lib::network_client;
-
-use percent_encoding::percent_decode;
-
-use rocket::http::RawStr;
-use rocket::request::{FlashMessage, Form};
-use rocket::response::{Flash, NamedFile, Redirect};
-
-use rocket_contrib::templates::Template;
 
 #[get("/")]
 pub fn index() -> Template {

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -48,10 +48,16 @@ use rocket_contrib::templates::Template;
 
 use peach_lib::network_client;
 
-use crate::context::*;
-use crate::device::*;
-use crate::monitor::*;
-use crate::network::*;
+use crate::context::{
+    DeviceContext, ErrorContext, HelpContext, HomeContext, LoginContext, MessageContext,
+    NetworkAddContext, NetworkAlertContext, NetworkContext, NetworkDetailContext,
+    NetworkListContext, PeerContext, ProfileContext, ShutdownContext,
+};
+use crate::device;
+use crate::monitor;
+use crate::monitor::Threshold;
+use crate::network;
+use crate::network::{Ssid, WiFi};
 
 #[get("/")]
 pub fn index() -> Template {
@@ -81,7 +87,7 @@ pub fn device_stats(flash: Option<FlashMessage>) -> Template {
 
 #[get("/device/reboot")]
 pub fn reboot_cmd() -> Flash<Redirect> {
-    match device_reboot() {
+    match device::reboot() {
         Ok(_) => Flash::success(Redirect::to("/shutdown"), "Rebooting the device"),
         Err(_) => Flash::error(Redirect::to("/shutdown"), "Failed to reboot the device"),
     }
@@ -89,7 +95,7 @@ pub fn reboot_cmd() -> Flash<Redirect> {
 
 #[get("/device/shutdown")]
 pub fn shutdown_cmd() -> Flash<Redirect> {
-    match device_shutdown() {
+    match device::shutdown() {
         Ok(_) => Flash::success(Redirect::to("/shutdown"), "Shutting down the device"),
         Err(_) => Flash::error(Redirect::to("/shutdown"), "Failed to shutdown the device"),
     }
@@ -140,7 +146,7 @@ pub fn logout() -> Flash<Redirect> {
 }
 
 #[get("/network")]
-pub fn network(flash: Option<FlashMessage>) -> Template {
+pub fn network_home(flash: Option<FlashMessage>) -> Template {
     // assign context through context_builder call
     let mut context = NetworkContext::build();
     // set back button (nav) url
@@ -255,7 +261,7 @@ pub fn add_credentials(wifi: Form<WiFi>) -> Template {
     // note: this is nicer but it's an unstable feature:
     //       if check_saved_aps(&wifi.ssid).contains(true)
     // use unwrap_or instead, set value to false if err is returned
-    let creds_exist = check_saved_aps(&wifi.ssid).unwrap_or(false);
+    let creds_exist = network::check_saved_aps(&wifi.ssid).unwrap_or(false);
     if creds_exist {
         let mut context = NetworkAddContext::build();
         context.back = Some("/network".to_string());
@@ -313,7 +319,7 @@ pub fn wifi_usage(flash: Option<FlashMessage>) -> Template {
 
 #[post("/network/wifi/usage", data = "<thresholds>")]
 pub fn wifi_usage_alerts(thresholds: Form<Threshold>) -> Flash<Redirect> {
-    match update_store(thresholds.into_inner()) {
+    match monitor::update_store(thresholds.into_inner()) {
         Ok(_) => {
             debug!("WiFi data usage thresholds updated.");
             Flash::success(
@@ -334,7 +340,7 @@ pub fn wifi_usage_alerts(thresholds: Form<Threshold>) -> Flash<Redirect> {
 #[get("/network/wifi/usage/reset")]
 pub fn wifi_usage_reset() -> Flash<Redirect> {
     let url = uri!(wifi_usage);
-    match reset_data() {
+    match monitor::reset_data() {
         Ok(_) => Flash::success(Redirect::to(url), "Reset stored network traffic total"),
         Err(_) => Flash::error(
             Redirect::to(url),
@@ -359,8 +365,8 @@ pub fn connect_wifi(network: Form<Ssid>) -> Flash<Redirect> {
 #[post("/network/wifi/disconnect", data = "<network>")]
 pub fn disconnect_wifi(network: Form<Ssid>) -> Flash<Redirect> {
     let ssid = &network.ssid;
-    let url = uri!(network);
-    match network_disable("wlan0", &ssid) {
+    let url = uri!(network_home);
+    match network::disable("wlan0", &ssid) {
         Ok(_) => Flash::success(Redirect::to(url), "Disconnected from WiFi network"),
         Err(_) => Flash::error(Redirect::to(url), "Failed to disconnect from WiFi network"),
     }
@@ -369,8 +375,8 @@ pub fn disconnect_wifi(network: Form<Ssid>) -> Flash<Redirect> {
 #[post("/network/wifi/forget", data = "<network>")]
 pub fn forget_wifi(network: Form<Ssid>) -> Flash<Redirect> {
     let ssid = &network.ssid;
-    let url = uri!(network);
-    match forget_network("wlan0", &ssid) {
+    let url = uri!(network_home);
+    match network::forget("wlan0", &ssid) {
         Ok(_) => Flash::success(Redirect::to(url), "WiFi credentials removed"),
         Err(_) => Flash::error(
             Redirect::to(url),
@@ -405,7 +411,7 @@ pub fn wifi_set_password(wifi: Form<WiFi>) -> Flash<Redirect> {
     let ssid = &wifi.ssid;
     let pass = &wifi.pass;
     let url = uri!(network_detail: ssid);
-    match update_password("wlan0", ssid, pass) {
+    match network::update_password("wlan0", ssid, pass) {
         Ok(_) => Flash::success(Redirect::to(url), "WiFi password updated".to_string()),
         Err(_) => Flash::error(
             Redirect::to(url),

--- a/src/ws.rs
+++ b/src/ws.rs
@@ -4,6 +4,7 @@
 use std::io;
 use std::thread;
 
+use log::{debug, info};
 use websocket::sync::Server;
 use websocket::{Message, OwnedMessage};
 


### PR DESCRIPTION
This PR replaces all `extern` statements with appropriately-scoped `use` statements. Function names in modules (such as `src/device.rs`) have been renamed to allow for idiomatic imports and function calls (e.g. instead of calling `device_shutdown()` we now call `device::shutdown()`).

An unused dependency (`get_if_addrs = "0.5"`) was removed.