### PR TITLE
Less duplicate code in save dns configurations and improved error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ maintenance = { status = "actively-developed" }
 env_logger = "0.8"
 log = "0.4"
 nest = "1.0.0"
-peach-lib = { git = "https://github.com/peachcloud/peach-lib", branch = "main" }
+peach-lib = { git = "https://github.com/peachcloud/peach-lib", branch = "errors" }
 percent-encoding = "2.1.0"
 rocket = "0.4.6"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,26 @@
+//!! different types of PeachWebError
+
+use peach_lib::{serde_json, serde_yaml};
+use snafu::Snafu;
+
+#[derive(Debug, Snafu)]
+pub enum PeachWebError {
+    #[snafu(display("Error loading serde json"))]
+    Serde { source: serde_json::error::Error },
+    #[snafu(display("Error loading peach-config yaml"))]
+    YamlError { source: serde_yaml::Error },
+    #[snafu(display("{}", msg))]
+    FailedToRegisterDynDomain { msg: String },
+}
+
+impl From<serde_json::error::Error> for PeachWebError {
+    fn from(err: serde_json::error::Error) -> PeachWebError {
+        PeachWebError::Serde { source: err }
+    }
+}
+
+impl From<serde_yaml::Error> for PeachWebError {
+    fn from(err: serde_yaml::Error) -> PeachWebError {
+        PeachWebError::YamlError { source: err }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@
 
 pub mod context;
 pub mod device;
+pub mod error;
 pub mod json_api;
 pub mod monitor;
 pub mod network;
@@ -55,57 +56,57 @@ fn rocket() -> rocket::Rocket {
         .mount(
             "/",
             routes![
-                add_credentials,        // WEB ROUTE
-                connect_wifi,           // WEB ROUTE
-                disconnect_wifi,        // WEB ROUTE
-                deploy_ap,              // WEB ROUTE
-                deploy_client,          // WEB ROUTE
-                device_stats,           // WEB ROUTE
-                files,                  // WEB ROUTE
-                forget_wifi,            // WEB ROUTE
-                help,                   // WEB ROUTE
-                index,                  // WEB ROUTE
-                login,                  // WEB ROUTE
-                logout,                 // WEB ROUTE
-                messages,               // WEB ROUTE
-                network_home,           // WEB ROUTE
-                network_add_ssid,       // WEB ROUTE
-                network_add_wifi,       // WEB ROUTE
-                network_detail,         // WEB ROUTE
-                peers,                  // WEB ROUTE
-                profile,                // WEB ROUTE
-                reboot_cmd,             // WEB ROUTE
-                shutdown_cmd,           // WEB ROUTE
-                shutdown_menu,          // WEB ROUTE
-                wifi_list,              // WEB ROUTE
-                wifi_password,          // WEB ROUTE
-                wifi_set_password,      // WEB ROUTE
-                wifi_usage,             // WEB ROUTE
-                wifi_usage_alerts,      // WEB ROUTE
-                wifi_usage_reset,       // WEB ROUTE
-                configure_dns,          // WEB ROUTE
-                configure_dns_post,     // WEB ROUTE
-                activate_ap,            // JSON API
-                activate_client,        // JSON API
-                add_wifi,               // JSON API
-                connect_ap,             // JSON API
-                disconnect_ap,          // JSON API
-                forget_ap,              // JSON API
-                modify_password,        // JSON API
-                ping_pong,              // JSON API
-                ping_network,           // JSON API
-                ping_oled,              // JSON API
-                ping_stats,             // JSON API
-                reset_data_total,       // JSON API
-                return_ip,              // JSON API
-                return_rssi,            // JSON API
-                return_ssid,            // JSON API
-                return_state,           // JSON API
-                return_status,          // JSON API
-                reboot_device,          // JSON API
-                scan_networks,          // JSON API
-                shutdown_device,        // JSON API
-                update_wifi_alerts,     // JSON API
+                add_credentials,                 // WEB ROUTE
+                connect_wifi,                    // WEB ROUTE
+                disconnect_wifi,                 // WEB ROUTE
+                deploy_ap,                       // WEB ROUTE
+                deploy_client,                   // WEB ROUTE
+                device_stats,                    // WEB ROUTE
+                files,                           // WEB ROUTE
+                forget_wifi,                     // WEB ROUTE
+                help,                            // WEB ROUTE
+                index,                           // WEB ROUTE
+                login,                           // WEB ROUTE
+                logout,                          // WEB ROUTE
+                messages,                        // WEB ROUTE
+                network_home,                    // WEB ROUTE
+                network_add_ssid,                // WEB ROUTE
+                network_add_wifi,                // WEB ROUTE
+                network_detail,                  // WEB ROUTE
+                peers,                           // WEB ROUTE
+                profile,                         // WEB ROUTE
+                reboot_cmd,                      // WEB ROUTE
+                shutdown_cmd,                    // WEB ROUTE
+                shutdown_menu,                   // WEB ROUTE
+                wifi_list,                       // WEB ROUTE
+                wifi_password,                   // WEB ROUTE
+                wifi_set_password,               // WEB ROUTE
+                wifi_usage,                      // WEB ROUTE
+                wifi_usage_alerts,               // WEB ROUTE
+                wifi_usage_reset,                // WEB ROUTE
+                configure_dns,                   // WEB ROUTE
+                configure_dns_post,              // WEB ROUTE
+                activate_ap,                     // JSON API
+                activate_client,                 // JSON API
+                add_wifi,                        // JSON API
+                connect_ap,                      // JSON API
+                disconnect_ap,                   // JSON API
+                forget_ap,                       // JSON API
+                modify_password,                 // JSON API
+                ping_pong,                       // JSON API
+                ping_network,                    // JSON API
+                ping_oled,                       // JSON API
+                ping_stats,                      // JSON API
+                reset_data_total,                // JSON API
+                return_ip,                       // JSON API
+                return_rssi,                     // JSON API
+                return_ssid,                     // JSON API
+                return_state,                    // JSON API
+                return_status,                   // JSON API
+                reboot_device,                   // JSON API
+                scan_networks,                   // JSON API
+                shutdown_device,                 // JSON API
+                update_wifi_alerts,              // JSON API
                 save_dns_configuration_endpoint, // JSON API
             ],
         )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,7 +106,7 @@ fn rocket() -> rocket::Rocket {
                 scan_networks,          // JSON API
                 shutdown_device,        // JSON API
                 update_wifi_alerts,     // JSON API
-                save_dns_configuration, // JSON API
+                save_dns_configuration_endpoint, // JSON API
             ],
         )
         .register(catchers![not_found, internal_error])

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -60,6 +60,7 @@ use crate::monitor;
 use crate::monitor::Threshold;
 use crate::network::{DnsForm, Ssid, WiFi};
 use crate::utils::{check_is_new_dyndns_domain, get_full_dynamic_domain};
+use crate::json_api::{save_dns_configuration, DnsConfigError};
 
 #[get("/")]
 pub fn index() -> Template {
@@ -357,57 +358,29 @@ pub fn configure_dns(flash: Option<FlashMessage>) -> Template {
 
 #[post("/network/dns", data = "<dns>")]
 pub fn configure_dns_post(dns: Form<DnsForm>) -> Template {
-    config_manager::set_external_domain(&dns.external_domain).unwrap();
-    config_manager::set_dyndns_enabled_value(dns.enable_dyndns).unwrap();
-    // TODO: handle errors
-    if dns.enable_dyndns {
-        let full_dynamic_domain = get_full_dynamic_domain(&dns.dynamic_domain);
-        let is_new_domain = check_is_new_dyndns_domain(&full_dynamic_domain);
-        if is_new_domain {
-            match dyndns_client::register_domain(&full_dynamic_domain) {
-                Ok(_) => {
-                    info!("registered dyndns domain");
-                    let mut context = ConfigureDNSContext::build();
-                    // set back icon link to network route
-                    context.back = Some("/network".to_string());
-                    context.title = Some("Configure DNS".to_string());
-                    context.flash_name = Some("success".to_string());
-                    context.flash_msg =
-                        Some("New dynamic dns configuration is now enabled".to_string());
-                    // template_dir is set in Rocket.toml
-                    Template::render("configure_dns", &context)
-                }
-                Err(err) => {
-                    info!("Failed to add dyndns domain: {:?}", err);
-                    let mut context = ConfigureDNSContext::build();
-                    // set back icon link to network route
-                    context.back = Some("/network".to_string());
-                    context.title = Some("Configure DNS".to_string());
-                    context.flash_name = Some("error".to_string());
-                    context.flash_msg = Some("Failed to save dns configurations".to_string());
-                    // template_dir is set in Rocket.toml
-                    Template::render("configure_dns", &context)
-                }
-            }
-        } else {
+    let result = save_dns_configuration(dns.into_inner());
+    match result {
+        Ok(_) => {
             let mut context = ConfigureDNSContext::build();
             // set back icon link to network route
             context.back = Some("/network".to_string());
             context.title = Some("Configure DNS".to_string());
             context.flash_name = Some("success".to_string());
-            context.flash_msg = Some("New dns configuration is now enabled".to_string());
+            context.flash_msg =
+                Some("New dynamic dns configuration is now enabled".to_string());
             // template_dir is set in Rocket.toml
             Template::render("configure_dns", &context)
         }
-    } else {
-        let mut context = ConfigureDNSContext::build();
-        // set back icon link to network route
-        context.back = Some("/network".to_string());
-        context.title = Some("Configure DNS".to_string());
-        context.flash_name = Some("success".to_string());
-        context.flash_msg = Some("New dns configuration is now enabled".to_string());
-        // template_dir is set in Rocket.toml
-        Template::render("configure_dns", &context)
+        Err(DnsConfigError::FailedToRegisterDomain(msg)) => {
+            let mut context = ConfigureDNSContext::build();
+            // set back icon link to network route
+            context.back = Some("/network".to_string());
+            context.title = Some("Configure DNS".to_string());
+            context.flash_name = Some("error".to_string());
+            context.flash_msg = Some("Failed to save dns configurations".to_string());
+            // template_dir is set in Rocket.toml
+            Template::render("configure_dns", &context)
+        }
     }
 }
 


### PR DESCRIPTION
This PR includes:
- Adds PeachWebError type using Snafu, which allows for nice display of "Dyn Domain already registered error"
- Adds save_dns_configuration function which is shared by json_api_endpoint and no-js route (I'm excited about this pattern! Basically, save_dns_configuration returns a Result, and then the json_api and no-js route can both just consume this result, and use a match statement to decide what to return, without duplicating the actual code in both places... this is a pattern that could also possibly be replicated for the other endpoints)

I probably should have put these two changes in two separate PRs, but I ended up doing them together. 

Example error message using the nicer error handling:
<img width="1440" alt="Screen Shot 2021-06-07 at 1 35 04 PM" src="https://user-images.githubusercontent.com/1831536/121076767-c8102f80-c7a4-11eb-9a94-3b317efcea9e.png">

@mycognosist we can discuss this PR too on the call