### PR TITLE
Keep peach-web up to date with peach-lib flattened config keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1334,8 +1334,8 @@ dependencies = [
 
 [[package]]
 name = "peach-lib"
-version = "1.2.4"
-source = "git+https://github.com/peachcloud/peach-lib?branch=errors#d84220b446cf1b8d2c2066244863298d2a15c99c"
+version = "1.2.5"
+source = "git+https://github.com/peachcloud/peach-lib?branch=main#839a957054bf680b53a79c8b24e3f12bb10b3c9d"
 dependencies = [
  "env_logger 0.6.2",
  "jsonrpc-client-core",
@@ -1350,7 +1350,7 @@ dependencies = [
 
 [[package]]
 name = "peach-web"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "env_logger 0.8.3",
  "log 0.4.14",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "peach-web"
-version = "0.4.5"
+version = "0.4.6"
 authors = ["Andrew Reid <gnomad@cryptolab.net>"]
 edition = "2018"
 description = "peach-web is a web application which provides a web interface for monitoring and interacting with the PeachCloud device. This allows administration of the single-board computer (ie. Raspberry Pi) running PeachCloud, as well as the ssb-server and related plugins."
@@ -38,7 +38,7 @@ maintenance = { status = "actively-developed" }
 env_logger = "0.8"
 log = "0.4"
 nest = "1.0.0"
-peach-lib = { git = "https://github.com/peachcloud/peach-lib", branch = "errors" }
+peach-lib = { git = "https://github.com/peachcloud/peach-lib", branch = "main" }
 percent-encoding = "2.1.0"
 rocket = "0.4.6"
 serde = { version = "1.0", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # peach-web
 
-[![Build Status](https://travis-ci.com/peachcloud/peach-web.svg?branch=master)](https://travis-ci.com/peachcloud/peach-web) ![Generic badge](https://img.shields.io/badge/version-0.4.5-<COLOR>.svg)
+[![Build Status](https://travis-ci.com/peachcloud/peach-web.svg?branch=master)](https://travis-ci.com/peachcloud/peach-web) ![Generic badge](https://img.shields.io/badge/version-0.4.6-<COLOR>.svg)
 
 ## Web Interface for PeachCloud
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -219,7 +219,6 @@ pub struct ConfigureDNSContext {
     pub external_domain: String,
     pub dyndns_subdomain: String,
     pub enable_dyndns: bool,
-    pub ip: Option<String>,
     pub back: Option<String>,
     pub title: Option<String>,
     pub flash_name: Option<String>,
@@ -229,13 +228,12 @@ pub struct ConfigureDNSContext {
 impl ConfigureDNSContext {
     pub fn build() -> ConfigureDNSContext {
         let peach_config = load_peach_config().unwrap();
-        let dyndns_fulldomain = peach_config.peach_dyndns.domain;
+        let dyndns_fulldomain = peach_config.dyn_domain;
         let dyndns_subdomain = get_dyndns_subdomain(&dyndns_fulldomain);
         ConfigureDNSContext {
             external_domain: peach_config.external_domain,
             dyndns_subdomain,
-            enable_dyndns: peach_config.peach_dyndns.enabled,
-            ip: Some("1.1.1.1".to_string()),
+            enable_dyndns: peach_config.dyn_enabled,
             back: None,
             title: None,
             flash_name: None,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -18,6 +18,6 @@ pub fn get_dyndns_subdomain(dyndns_full_domain: &str) -> String {
 // helper function which checks if a dyndns domain is new
 pub fn check_is_new_dyndns_domain(dyndns_full_domain: &str) -> bool {
     let peach_config = load_peach_config().unwrap();
-    let previous_dyndns_domain = peach_config.peach_dyndns.domain;
+    let previous_dyndns_domain = peach_config.dyn_domain;
     dyndns_full_domain != previous_dyndns_domain
 }


### PR DESCRIPTION
This PR keeps peach-web in sync with peach-lib after flattening the names of the keys in config.yml