### PR TITLE
Send password reset via ssb dm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1334,7 +1334,7 @@ dependencies = [
 
 [[package]]
 name = "peach-lib"
-version = "1.2.13"
+version = "1.2.14"
 dependencies = [
  "chrono",
  "env_logger 0.6.2",

--- a/debian/postinst
+++ b/debian/postinst
@@ -20,6 +20,9 @@ server {
     auth_basic           "If you have forgotten your password visit: http://peach.local/send_password_reset/";
     auth_basic_user_file /var/lib/peachcloud/passwords/htpasswd;
 
+    # remove trailing slash if found
+    rewrite ^/(.*)/$ /$1 permanent;
+
     location / {
 		proxy_pass http://127.0.0.1:3000;
 	}
@@ -51,6 +54,12 @@ server {
    }
 
 }
+EOF
+
+cat <<EOF > /etc/sudoers.d/peach-web
+# allow peach-web to run commands as peach-go-sbot without a password
+peach-web ALL=(peach-go-sbot) NOPASSWD:ALL
+
 EOF
 
 # cargo deb automatically replaces this token below, see https://github.com/mmstick/cargo-deb/blob/master/systemd.md

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,7 @@ fn rocket() -> rocket::Rocket {
                 configure_dns_post,              // WEB ROUTE
                 change_password,                 // WEB ROUTE
                 reset_password,                  // WEB ROUTE
+                reset_password_post,             // WEB ROUTE
                 send_password_reset_page,        // WEB ROUTE
                 send_password_reset_post,        // WEB ROUTE
                 activate_ap,                     // JSON API

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -459,7 +459,7 @@ pub fn reset_password_post(reset_password_form: Form<ResetPasswordForm>) -> Temp
             context.back = Some("/".to_string());
             context.title = Some("Reset Password".to_string());
             context.flash_name = Some("success".to_string());
-            let flash_msg = "New password is now saved. Return home to login.".to_string();
+            let flash_msg = "New password is now saved. Return home to login".to_string();
             context.flash_msg = Some(flash_msg);
             Template::render("password/reset_password", &context)
         }

--- a/templates/password/reset_password.html.tera
+++ b/templates/password/reset_password.html.tera
@@ -5,7 +5,7 @@
 
         <div class="form-container">
 
-              <form id="changePassword" action="/reset_password/" method="post">
+              <form id="changePassword" action="/reset_password" method="post">
               <div class="input-wrapper">
                 <!-- input for temporary password -->
                 <label id="temporary_password" class="label-small input-label font-near-black">

--- a/templates/password/send_password_reset.html.tera
+++ b/templates/password/send_password_reset.html.tera
@@ -9,7 +9,7 @@
                 The temporary password will be sent in an SSB private message to the admin of this device.
             </p>
 
-           <form id="sendPasswordReset" action="/send_password_reset/" method="post">
+           <form id="sendPasswordReset" action="/send_password_reset" method="post">
                 <div id="buttonDiv">
                     <input type="submit" class="button center button-secondary" value="Send Password Reset" title="Send Password Reset Link"/>
                 </div>


### PR DESCRIPTION
Connected to this PR in peach-lib: https://github.com/peachcloud/peach-lib/pull/22

This PR also includes:
- adding an nginx config which removes trailing slashes on URLs if they appear (as it seems that is the convention we are using, is to include trailing slashes in rocket routes). 
- a sudoers file installed via postinst which lets peach-web become peach-go-sbot without a password
- bug fixes 

Here is a screenshot of receiving password reset links in Patchwork.. so cool!

![Screenshot from 2021-07-13 14-31-24](https://user-images.githubusercontent.com/1831536/125508072-b188eefb-ba8e-43b4-ad13-300231dd414f.png)

cc @mycognosist 

